### PR TITLE
Update PostcodeServiceTest and PostcodeRuleTest to not call out to external API

### DIFF
--- a/src/PostcodesServiceProvider.php
+++ b/src/PostcodesServiceProvider.php
@@ -24,7 +24,7 @@ class PostcodesServiceProvider extends ServiceProvider
         });
 
         \Illuminate\Validation\Rule::macro('postcode', function () {
-            return new \JustSteveKing\LaravelPostcodes\Rules\Postcode();
+            return new \JustSteveKing\LaravelPostcodes\Rules\Postcode(resolve(PostcodeService::class));
         });
     }
 

--- a/src/Rules/Postcode.php
+++ b/src/Rules/Postcode.php
@@ -16,9 +16,9 @@ class Postcode implements Rule
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(PostcodeService $service)
     {
-        $this->service = resolve(PostcodeService::class);
+        $this->service = $service;
     }
 
     /**

--- a/tests/Unit/PostcodeRuleTest.php
+++ b/tests/Unit/PostcodeRuleTest.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace JustSteveKing\LaravelPostcodes\Unit;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Validation\Rule;
+use JustSteveKing\LaravelPostcodes\Service\PostcodeService;
 use JustSteveKing\LaravelPostcodes\TestCase;
 use JustSteveKing\LaravelPostcodes\Rules\Postcode;
 
@@ -15,34 +20,44 @@ class PostcodeRuleTest extends TestCase
      */
     protected $rule;
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->rule = new Postcode();
-    }
-
     public function testPostcodeMacro()
     {
+        $this->setupRule(200);
+
         $this->assertInstanceOf(Postcode::class, Rule::postcode());
     }
 
     public function testValidPostcodePasses()
     {
+        $this->setupRule(200, json_encode(['result' => true]));
+
         $postcode = 'CF10 4UW';
         $this->assertTrue($this->rule->passes('postcode', $postcode));
     }
 
     public function testInvalidPostcodeFails()
     {
+        $this->setupRule(200, json_encode(['result' => false]));
+
         $postcode = 'testing';
         $this->assertFalse($this->rule->passes('postcode', $postcode));
     }
 
     public function testValidationMessageIsCorrect()
     {
+        $this->setupRule(200);
+
         $string = 'The submitted postcode is not a valid UK postcode';
 
         $this->assertEquals($this->rule->message(), $string);
+    }
+
+    private function setupRule(int $status, string $body = null): void
+    {
+        $mock = new MockHandler([new Response($status, [], $body)]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $this->rule = new Postcode(new PostcodeService($client));
     }
 }

--- a/tests/Unit/PostcodeServiceTest.php
+++ b/tests/Unit/PostcodeServiceTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace JustSteveKing\LaravelPostcodes\Unit;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 use JustSteveKing\LaravelPostcodes\TestCase;
 use JustSteveKing\LaravelPostcodes\Service\PostcodeService;
 
@@ -11,37 +15,42 @@ class PostcodeServiceTest extends TestCase
 {
     protected $postcode = 'N11 1QZ';
 
-    protected $service;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->service = resolve(PostcodeService::class);
-    }
-
     public function testServiceIsCorrectType()
     {
-        $this->assertInstanceOf(PostcodeService::class, $this->service);
+        $this->assertInstanceOf(PostcodeService::class, $this->service(200));
     }
 
     public function testServiceCanValidatePostcode()
     {
-        $this->assertEquals(false, $this->service->validate('test'));
-        $this->assertTrue($this->service->validate($this->postcode));
+        $serviceFail = $this->service(200, json_encode(['result' => false]));
+        $this->assertEquals(false, $serviceFail->validate('test'));
+
+        $serviceSuccess = $this->service(200, json_encode(['result' => true]));
+        $this->assertTrue($serviceSuccess->validate($this->postcode));
     }
 
     public function testServiceCanGetPostcode()
     {
-        $result = $this->service->getPostcode($this->postcode);
-        
+        $service = $this->service(200, json_encode(['result' => ['postcode' => $this->postcode]]));
+        $result = $service->getPostcode($this->postcode);
+
         $this->assertEquals($result->postcode, $this->postcode);
     }
 
     public function testServiceCanGetRandomPostcode()
     {
-        $result = $this->service->getRandomPostcode();
+        $service = $this->service(200, json_encode(['result' => ['postcode' => $this->postcode]]));
+        $result = $service->getRandomPostcode();
 
         $this->assertNotNull($result->postcode);
+    }
+
+    private function service(int $status, string $body = null): PostcodeService
+    {
+        $mock = new MockHandler([new Response($status, [], $body)]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        return new PostcodeService($client);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates `PostcodeServiceTest` and `PostcodeRuleTest` to no longer require the external API.

## Motivation and context

This solves running tests without spamming the postcode API. It also solves running tests when offline and running tests when the external API is down.

This has also made a significant performance increase.

Fixes #12 

## How has this been tested?

Disconnected my internet and re-ran the unit tests. They still work and pass.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
