### PR TITLE
Fix Instructions - Call in service

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ If you want to interact with the service itself
 ```php
 <?php 
 
+use JustSteveKing\LaravelPostcodes\Service\PostcodeService;
+
 class SomeController extends Controller
 {
     protected $postcodes;


### PR DESCRIPTION
Took me a few moments to figure this out, may help someone else.

## Description

Fixes instructions to pull in the Service Provider.

## Motivation and context

It took me some moments to figure out what was missing. There is nothing about this in the current instructions.

## How has this been tested?

Works on Laravel 6.


## Types of changes

Just the instructions
