### PR TITLE
Update PostcodeService.php to include Outcode Validation

### DIFF
--- a/src/Service/PostcodeService.php
+++ b/src/Service/PostcodeService.php
@@ -45,6 +45,21 @@ class PostcodeService
     {
         return $this->getResponse("postcodes/$postcode/validate");
     }
+    
+    /**
+     * Validate a Outcode against the RegEx
+     *
+     * @param string $postcode
+     *
+     * @return bool
+     */
+    public function validateOutcode(string $postcode): bool
+    {
+      if (preg_match('#^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW])', $postcode)) {
+        return TRUE;
+      }
+      return FALSE;
+    }
 
     /**
      * Get the address details from a postcode

--- a/src/Service/PostcodeService.php
+++ b/src/Service/PostcodeService.php
@@ -55,7 +55,7 @@ class PostcodeService
      */
     public function validateOutcode(string $postcode): bool
     {
-      if (preg_match('#^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW])', $postcode)) {
+      if (preg_match('#^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW]))#', $postcode)) {
         return TRUE;
       }
       return FALSE;


### PR DESCRIPTION
Simple RegEx for outcode validation.

## Description

Describe your changes in detail.

## Motivation and context

Simple RegEx for outcode validation.  Using Government Provided code ttp://webarchive.nationalarchives.gov.uk/+/http://www.cabinetoffice.gov.uk/media/254290/GDS%20Catalogue%20Vol%202.pdf (page 11)

On GEO services, users type in the first past of the postcode. There is often no need to enter the full postcode. You need to validate that its correct before pushing to postcodes.io as they dont offer outcode validation.
