### PR TITLE
REGEX Postcode Validation

### DIFF
--- a/src/Service/PostcodeService.php
+++ b/src/Service/PostcodeService.php
@@ -41,15 +41,15 @@ class PostcodeService
      *
      * @return bool
      */
-    public function validate(string $postcode, $pre_validate = TRUE): bool
-    {
-        if($pre_validate == TRUE)
-            if (preg_match('#^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW]) ?[0-9][ABD-HJLNP-UW-Z]{2})$#', $postcode)) {
-                return FALSE;
-            }
-        }        
-        return $this->getResponse("postcodes/$postcode/validate");
-    }
+     public function validate(string $postcode, $preValidate = true): bool
+     {
+         if($preValidate == true){
+             if (preg_match('#^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW]) ?[0-9][ABD-HJLNP-UW-Z]{2})$#', $postcode)) {
+                 return false;
+             }
+         }
+         return $this->getResponse("postcodes/$postcode/validate");
+     }
 
     /**
      * Get the address details from a postcode

--- a/src/Service/PostcodeService.php
+++ b/src/Service/PostcodeService.php
@@ -41,8 +41,13 @@ class PostcodeService
      *
      * @return bool
      */
-    public function validate(string $postcode): bool
+    public function validate(string $postcode, $pre_validate = TRUE): bool
     {
+        if($pre_validate == TRUE)
+            if (preg_match('#^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW]) ?[0-9][ABD-HJLNP-UW-Z]{2})$#', $postcode)) {
+                return FALSE;
+            }
+        }        
         return $this->getResponse("postcodes/$postcode/validate");
     }
 


### PR DESCRIPTION
Faster to respond false & Reduces API Calls.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Introduces RegEx validation for the postcode.

## Motivation and context

I'm using ajax and when people are typing, it is sending repeated API requests even though they have not finished. Sure I've added a delay but this is extra clean.

Provides Developer with a prompter decline if it's impossible to be a postcode, before checking with the API to see if it is a valid postcode.

REGEX Source: http://webarchive.nationalarchives.gov.uk/+/http://www.cabinetoffice.gov.uk/media/254290/GDS%20Catalogue%20Vol%202.pdf (page 11)

