### PR TITLE
Fixing Array to string conversion warning on getPoscodes method

### DIFF
--- a/src/Service/PostcodeService.php
+++ b/src/Service/PostcodeService.php
@@ -89,12 +89,14 @@ class PostcodeService
      */
     public function getPostcodes(array $postcodes, array $filter = []): Collection
     {
+        $queryParams = '';
+
         if (!empty($filter)) {
-            $filter = Query::build(['filter' => implode(',', $filter)]);
+            $queryParams = Query::build(['filter' => implode(',', $filter)]);
         }
 
         return collect($this->getResponse(
-            'postcodes?' . $filter,
+            'postcodes?' . $queryParams,
             'POST',
             ['postcodes' => array_values($postcodes)]
         ))->map(function ($item) {


### PR DESCRIPTION
If the filters argument is left to default the `getPostcodes` method will fail when it tried to convert an empty array to a string.